### PR TITLE
Added the bootJar task. Packages a runnable PROSECO server.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+	// Spring boot plugin
+	plugins {
+		id "org.springframework.boot" version "2.0.5.RELEASE"
+	}
 
 	//IDE
 	apply plugin: "java"
@@ -49,7 +53,9 @@ dependencies {
 	compile 'junit:junit:4.12'
 	
 	// Spring Boot
-	compile group: 'org.springframework.boot', name: 'spring-boot-starter-thymeleaf', version: '1.5.16.RELEASE'
+	compile group: 'org.springframework.boot', name: 'spring-boot-starter-thymeleaf', version: '2.0.5.RELEASE'
+	compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.0.5.RELEASE'
+
 	
 	// Jackson for YAML
 	compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.10'
@@ -77,4 +83,12 @@ repositories {
 	maven {
         url "http://clojars.org/repo/"
     }
+}
+
+
+
+bootJar {
+	destinationDir = file("$rootDir")
+	baseName = 'PROSECOServer'
+	version = "0.0.1"
 }

--- a/src/de/upb/crc901/proseco/core/composition/CompositionAlgorithm.java
+++ b/src/de/upb/crc901/proseco/core/composition/CompositionAlgorithm.java
@@ -122,6 +122,7 @@ public class CompositionAlgorithm implements Runnable {
 				groundingCommand[1] = executionEnvironment.getProcessId();
 				groundingCommand[2] = executionEnvironment.getSearchOutputDirectory().getAbsolutePath() + File.separator + winningStrategy.get().getName();
 				groundingCommand[3] = executionEnvironment.getSearchOutputDirectory().getAbsolutePath() + File.separator + "final";
+				new File(groundingCommand[0]).setExecutable(true);
 				final ProcessBuilder pb = new ProcessBuilder(groundingCommand).directory(executionEnvironment.getGroundingDirectory());
 				// pb.redirectOutput(Redirect.appendTo(groundingLog)).redirectError(Redirect.appendTo(groundingLog));
 				pb.redirectOutput(Redirect.INHERIT).redirectError(Redirect.INHERIT);
@@ -147,6 +148,7 @@ public class CompositionAlgorithm implements Runnable {
 			deploymentCommand[1] = executionEnvironment.getProcessId();
 			deploymentCommand[2] = host;
 			deploymentCommand[3] = "" + port;
+			new File(deploymentCommand[0]).setExecutable(true);
 			logger.info("Deploying service {} to {}:{}", deploymentCommand[1], deploymentCommand[2], deploymentCommand[3]);
 			final ProcessBuilder pb = new ProcessBuilder(deploymentCommand);
 			pb.redirectOutput(Redirect.INHERIT).redirectError(Redirect.INHERIT);

--- a/src/de/upb/crc901/proseco/core/composition/StrategyExecutor.java
+++ b/src/de/upb/crc901/proseco/core/composition/StrategyExecutor.java
@@ -69,6 +69,7 @@ public class StrategyExecutor {
 			String outputPath = executionEnvironment.getSearchOutputDirectory().getAbsolutePath() + File.separator + strategyName;
 			commandArguments[3] = outputPath;
 			commandArguments[4] = "" + timeoutInSeconds;
+			new File(commandArguments[0]).setExecutable(true);
 			final ProcessBuilder pb = new ProcessBuilder(commandArguments).redirectOutput(Redirect.PIPE).redirectError(Redirect.PIPE);
 			System.out.print("Starting process for strategy " + strategyFolder + ": " + Arrays.toString(commandArguments));
 


### PR DESCRIPTION
- Strategy, ground and deployment scripts from prototypes are set to executable before running them. (Prevents the not executable error)
- Added the bootJar task which packages a runnable PROSECO server.
- Upgraded the spring boot dependency version  to '2.0.5.RELEASE'.